### PR TITLE
Handle text color properly for visited state.

### DIFF
--- a/build/sass/_import.scss
+++ b/build/sass/_import.scss
@@ -8,6 +8,7 @@ $font-face-rocket-button: "icon-font-rocket-button" !default;
 // Import
 @import "../../../rocket-propel/build/sass/import";
 
+@import "module/utilities";
 @import "module/drop-down";
 @import "module/loader";
 @import "module/setup";

--- a/build/sass/module/_setup.scss
+++ b/build/sass/module/_setup.scss
@@ -19,7 +19,7 @@
 	@include position(relative);
 	@include display(inline-block);
 	@include text-align(center);
-	@include text-colour(lighten(#000, 40%));
+	@include text-colour-with-visited(lighten(#000, 40%));
 	@include text-decoration(none);
 	@include vertical-align(middle);
 	@include border-no();
@@ -29,9 +29,6 @@
 	outline: none;
 	-webkit-appearance: none;
 
-	&:visited {
-		@include text-colour(lighten(#000, 40%));
-	}
 	.rocket-no-touch &:hover {
 		@include cursor(pointer);
 		@include background-colour($grey-x-light);

--- a/build/sass/module/_style.scss
+++ b/build/sass/module/_style.scss
@@ -11,7 +11,7 @@ $lightness-threshold-line: 98%;
 	@if $style == gradient {
 		// Setup
 		@if lightness($colour) < $lightness-threshold {
-			@include text-colour($white);
+			@include text-colour-with-visited($white);
 		}
 
 		// Gradient
@@ -27,10 +27,10 @@ $lightness-threshold-line: 98%;
 	@else if $style == line {
 		// Setup
 		@if lightness($colour) < $lightness-threshold-line {
-			@include text-colour($colour);
+			@include text-colour-with-visited($colour);
 		}
 		@else {
-			@include text-colour($white);
+			@include text-colour-with-visited($white);
 		}
 		background: transparent;
 		@include border($colour, $border-size);
@@ -44,13 +44,6 @@ $lightness-threshold-line: 98%;
       }
 
 		// States
-		@if $colour != #fff {
-			@if $colour != #EBEBEB {
-				&:visited {
-					@include text-colour($colour);
-				}
-			}
-		}
 		.rocket-no-touch &:hover {
 			// Check lightness
 			@if lightness($colour) > 80% {
@@ -85,18 +78,11 @@ $lightness-threshold-line: 98%;
 	@else {
 		// Setup
 		@if lightness($colour) < $lightness-threshold {
-			@include text-colour($white);
+			@include text-colour-with-visited($white);
 		}
 		@include background-color($colour);
 
 		// States
-		@if $colour != #fff {
-			@if $colour != #EBEBEB {
-				&:visited {
-					@include text-colour($white);
-				}
-			}
-		}
 		.rocket-no-touch &:hover {
 			// Check saturations
 			@if saturation($colour) > 0% {

--- a/build/sass/module/_utilities.scss
+++ b/build/sass/module/_utilities.scss
@@ -1,0 +1,7 @@
+@mixin text-colour-with-visited($colour) {
+	@include text-colour($colour);
+
+  &:visited {
+    @include text-colour($colour);
+  }
+}


### PR DESCRIPTION
Rocket-Button currently works beautifully on `<input>` and (presumably) `<button>` elements, but doesn't properly handle the visited state on `<a>` elements (for example, a dark green `<a>` button that's been visited has gray text, not white).

This pull request fixes that by always setting the visited text color when it sets the primary text color. (It's stupid that CSS pseudoclasses can't inherit from the element without a pseudoclass, but they can't.)

BTW, I didn't rebuild the generated CSS files because I don't understand how your build tools work (the only link to documentation seems to be a broken one from the NPM rocket-framework page). If you tell me how you've been building the CSS from the Sass source, I'll be happy to do it.